### PR TITLE
Fix: delete AssetStoreTools.meta

### DIFF
--- a/NativeWebSocket/Assets/AssetStoreTools.meta
+++ b/NativeWebSocket/Assets/AssetStoreTools.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: db80080e16f4b44f6ba12028661982db
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Hey @endel 

I get a lot of warnings from this file, we don't need it because we don't have an AssetStoreTools folder. FYI - Unity creates a ".meta" file for each folder.

Thanks! :smile: