### PR TITLE
Adds optional subprotocol

### DIFF
--- a/NativeWebSocket/Assets/WebSocket/WebSocket.cs
+++ b/NativeWebSocket/Assets/WebSocket/WebSocket.cs
@@ -240,6 +240,34 @@ namespace NativeWebSocket
       this.instanceId = instanceId;
     }
 
+    public WebSocket (string url, string subprotocol, Dictionary<string, string> headers = null) {
+      if (!WebSocketFactory.isInitialized) {
+        WebSocketFactory.Initialize ();
+      }
+
+      int instanceId = WebSocketFactory.WebSocketAllocate (url);
+      WebSocketFactory.instances.Add (instanceId, this);
+
+      WebSocketFactory.WebSocketAddSubProtocol(instanceId, subprotocol);
+
+      this.instanceId = instanceId;
+    }
+
+    public WebSocket (string url, List<string> subprotocols, Dictionary<string, string> headers = null) {
+      if (!WebSocketFactory.isInitialized) {
+        WebSocketFactory.Initialize ();
+      }
+
+      int instanceId = WebSocketFactory.WebSocketAllocate (url);
+      WebSocketFactory.instances.Add (instanceId, this);
+
+      foreach (string subprotocol in subprotocols) {
+        WebSocketFactory.WebSocketAddSubProtocol(instanceId, subprotocol);
+      }
+
+      this.instanceId = instanceId;
+    }
+
     ~WebSocket () {
       WebSocketFactory.HandleInstanceDestroy (this.instanceId);
     }
@@ -344,6 +372,7 @@ namespace NativeWebSocket
 
         private Uri uri;
         private Dictionary<string, string> headers;
+        private List<string> subprotocols;
         private ClientWebSocket m_Socket = new ClientWebSocket();
 
         private CancellationTokenSource m_TokenSource;
@@ -368,6 +397,48 @@ namespace NativeWebSocket
                 this.headers = headers;
             }
 
+            subprotocols = new List<string>();
+
+            string protocol = uri.Scheme;
+            if (!protocol.Equals("ws") && !protocol.Equals("wss"))
+                throw new ArgumentException("Unsupported protocol: " + protocol);
+        }
+
+        public WebSocket(string url, string subprotocol, Dictionary<string, string> headers = null)
+        {
+            uri = new Uri(url);
+
+            if (headers == null)
+            {
+                this.headers = new Dictionary<string, string>();
+            }
+            else
+            {
+                this.headers = headers;
+            }
+
+            subprotocols = new List<string> {subprotocol};
+
+            string protocol = uri.Scheme;
+            if (!protocol.Equals("ws") && !protocol.Equals("wss"))
+                throw new ArgumentException("Unsupported protocol: " + protocol);
+        }
+
+        public WebSocket(string url, List<string> subprotocols, Dictionary<string, string> headers = null)
+        {
+            uri = new Uri(url);
+
+            if (headers == null)
+            {
+                this.headers = new Dictionary<string, string>();
+            }
+            else
+            {
+                this.headers = headers;
+            }
+
+            this.subprotocols = subprotocols;
+
             string protocol = uri.Scheme;
             if (!protocol.Equals("ws") && !protocol.Equals("wss"))
                 throw new ArgumentException("Unsupported protocol: " + protocol);
@@ -390,6 +461,10 @@ namespace NativeWebSocket
                 foreach (var header in headers)
                 {
                     m_Socket.Options.SetRequestHeader(header.Key, header.Value);
+                }
+
+                foreach (string subprotocol in subprotocols) {
+                    m_Socket.Options.AddSubProtocol(subprotocol);
                 }
 
                 await m_Socket.ConnectAsync(uri, m_CancellationToken);
@@ -651,6 +726,9 @@ namespace NativeWebSocket
     /* WebSocket JSLIB callback setters and other functions */
     [DllImport ("__Internal")]
     public static extern int WebSocketAllocate (string url);
+
+    [DllImport ("__Internal")]
+    public static extern int WebSocketAddSubProtocol (int instanceId, string subprotocol);
 
     [DllImport ("__Internal")]
     public static extern void WebSocketFree (int instanceId);

--- a/NativeWebSocket/Assets/WebSocket/WebSocket.jslib
+++ b/NativeWebSocket/Assets/WebSocket/WebSocket.jslib
@@ -142,6 +142,7 @@ var LibraryWebSocket = {
 		var id = webSocketState.lastId++;
 
 		webSocketState.instances[id] = {
+		  subprotocols: [],
 			url: urlStr,
 			ws: null
 		};
@@ -149,6 +150,19 @@ var LibraryWebSocket = {
 		return id;
 
 	},
+
+  /**
+   * Add subprotocol to instance
+   *
+   * @param instanceId Instance ID
+   * @param subprotocol Subprotocol name to add to instance
+   */
+  WebSocketAddSubProtocol: function(instanceId, subprotocol) {
+
+    var subprotocolStr = Pointer_stringify(subprotocol);
+    webSocketState.instances[instanceId].subprotocols.push(subprotocolStr);
+
+  },
 
 	/**
 	 * Remove reference to WebSocket instance
@@ -188,7 +202,7 @@ var LibraryWebSocket = {
 		if (instance.ws !== null)
 			return -2;
 
-		instance.ws = new WebSocket(instance.url);
+		instance.ws = new WebSocket(instance.url, instance.subprotocols);
 
 		instance.ws.binaryType = 'arraybuffer';
 


### PR DESCRIPTION
I'm working on a legacy project that requires the subprotocol to be explicitly declared. This is possible in both the browser's `WebSocket` class, as well as C#'s `System.Net.WebSockets` system. 
This pull request adds optional constructors that allow passing a string or a list of strings with subprotocols defined.  
  
The browser implementation passes the subprotocols as the second argument to `new WebSocket()`  
The System.Net.WebSockets implementation adds the protocols via the `ClientWebSocket.Options.AddSubProtocol()` method