### PR TITLE
Adds optional subprotocols to UPM version

### DIFF
--- a/WebSocket/WebSocket.jslib
+++ b/WebSocket/WebSocket.jslib
@@ -142,11 +142,25 @@ var LibraryWebSocket = {
 		var id = webSocketState.lastId++;
 
 		webSocketState.instances[id] = {
+			subprotocols: [],
 			url: urlStr,
 			ws: null
 		};
 
 		return id;
+
+	},
+
+	/**
+	* Add subprotocol to instance
+	*
+	* @param instanceId Instance ID
+	* @param subprotocol Subprotocol name to add to instance
+	*/
+	WebSocketAddSubProtocol: function (instanceId, subprotocol) {
+		
+		var subprotocolStr = Pointer_stringify(subprotocol);
+		webSocketState.instances[instanceId].subprotocols.push(subprotocolStr);
 
 	},
 
@@ -188,7 +202,7 @@ var LibraryWebSocket = {
 		if (instance.ws !== null)
 			return -2;
 
-		instance.ws = new WebSocket(instance.url);
+		instance.ws = new WebSocket(instance.url, instance.subprotocols);
 
 		instance.ws.binaryType = 'arraybuffer';
 


### PR DESCRIPTION
I'm working on a legacy project that requires the subprotocol to be explicitly declared. This is possible in both the browser's `WebSocket` class, as well as C#'s `System.Net.WebSockets` system. 
This pull request adds optional constructors that allow passing a string or a list of strings with subprotocols defined.  
  
The browser implementation passes the subprotocols as the second argument to `new WebSocket()`  
The System.Net.WebSockets implementation adds the protocols via the `ClientWebSocket.Options.AddSubProtocol()` method

This is the same as #29, but on the #upm branch