### PR TITLE
Update package to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.endel.nativewebsocket",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "WebSocket client for Unity - with no external dependencies (WebGL, Native, Android, iOS, UWP).",
   "license": "Apache 2.0",
   "repository": {


### PR DESCRIPTION
Updates package.json to version 1.1.0  

Also, I recommend using Git tags and making the UPM URL `https://github.com/endel/NativeWebSocket.git#<latest-tag>`  
Using a branch URL in UPM means that if and when the branch has breaking changes, projects that depend on NativeWebSocket will break in unexpected ways.  
This is why we're using a forked and tagged version @bridgebase at the moment, we're afraid changes will be made on the #upm branch that might break our project on future checkouts.