### PR TITLE
Fix issues on Unity 2021.2

### DIFF
--- a/NativeWebSocket/Assets/WebSocket/WebSocket.jslib
+++ b/NativeWebSocket/Assets/WebSocket/WebSocket.jslib
@@ -137,7 +137,7 @@ var LibraryWebSocket = {
 	 */
 	WebSocketAllocate: function(url) {
 
-		var urlStr = Pointer_stringify(url);
+		var urlStr = UTF8ToString(url);
 		var id = webSocketState.lastId++;
 
 		webSocketState.instances[id] = {
@@ -158,7 +158,7 @@ var LibraryWebSocket = {
    */
   WebSocketAddSubProtocol: function(instanceId, subprotocol) {
 
-    var subprotocolStr = Pointer_stringify(subprotocol);
+    var subprotocolStr = UTF8ToString(subprotocol);
     webSocketState.instances[instanceId].subprotocols.push(subprotocolStr);
 
   },
@@ -311,7 +311,7 @@ var LibraryWebSocket = {
 		if (instance.ws.readyState === 3)
 			return -5;
 
-		var reason = ( reasonPtr ? Pointer_stringify(reasonPtr) : undefined );
+		var reason = ( reasonPtr ? UTF8ToString(reasonPtr) : undefined );
 
 		try {
 			instance.ws.close(code, reason);
@@ -365,7 +365,7 @@ var LibraryWebSocket = {
 		if (instance.ws.readyState !== 1)
 			return -6;
 
-		instance.ws.send(Pointer_stringify(message));
+		instance.ws.send(UTF8ToString(message));
 
 		return 0;
 

--- a/NativeWebSocket/Assets/WebSocket/WebSocket.jslib
+++ b/NativeWebSocket/Assets/WebSocket/WebSocket.jslib
@@ -61,7 +61,6 @@ if (typeof TextEncoder === "undefined") {
 }
 
 var LibraryWebSocket = {
-  $textEncoder: new TextEncoder(),
 	$webSocketState: {
 		/*
 		 * Map of instances
@@ -238,7 +237,7 @@ var LibraryWebSocket = {
 				}
 
       } else {
-				var dataBuffer = textEncoder.encode(ev.data);
+				var dataBuffer = (new TextEncoder()).encode(ev.data);
 
 				var buffer = _malloc(dataBuffer.length);
 				HEAPU8.set(dataBuffer, buffer);
@@ -392,5 +391,4 @@ var LibraryWebSocket = {
 };
 
 autoAddDeps(LibraryWebSocket, '$webSocketState');
-autoAddDeps(LibraryWebSocket, '$textEncoder');
 mergeInto(LibraryManager.library, LibraryWebSocket);


### PR DESCRIPTION
NativeWebSocket have an 2 issues in Unity 2021.2

1. Build fails with TextEncoder #53
2. Pointer_stringify is deprecated on emscripten (https://github.com/emscripten-core/emscripten/pull/8011)

Resolve 2 issues.