### PR TITLE
Perform array copies outside of `lock`s in Receive

### DIFF
--- a/NativeWebSocket/Assets/WebSocket/WebSocket.cs
+++ b/NativeWebSocket/Assets/WebSocket/WebSocket.cs
@@ -663,9 +663,10 @@ namespace NativeWebSocket
 
                         if (result.MessageType == WebSocketMessageType.Text)
                         {
+                            byte[] arr = ms.ToArray();
                             lock (IncomingMessageLock)
                             {
-                              m_MessageList.Add(ms.ToArray());
+                              m_MessageList.Add(arr);
                             }
 
                             //using (var reader = new StreamReader(ms, Encoding.UTF8))
@@ -676,9 +677,10 @@ namespace NativeWebSocket
                         }
                         else if (result.MessageType == WebSocketMessageType.Binary)
                         {
+                            byte[] arr = ms.ToArray();
                             lock (IncomingMessageLock)
                             {
-                              m_MessageList.Add(ms.ToArray());
+                              m_MessageList.Add(arr);
                             }
                         }
                         else if (result.MessageType == WebSocketMessageType.Close)


### PR DESCRIPTION
Call `ms.ToArray()` outside of the `lock (IncomingMessageLock)` sections in `Receive()`. This prevents the Unity main thread blocking on `IncomingMessageLock` if `ms.ToArray()` is copying a large number of bytes.