### PR TITLE
Support WebAssembly.Table

### DIFF
--- a/NativeWebSocket/Assets/WebSocket/WebSocket.jslib
+++ b/NativeWebSocket/Assets/WebSocket/WebSocket.jslib
@@ -149,8 +149,12 @@ var LibraryWebSocket = {
 			if (webSocketState.debug)
 				console.log("[JSLIB WebSocket] Connected.");
 
-			if (webSocketState.onOpen)
-				Module.dynCall_vi(webSocketState.onOpen, instanceId);
+			if (webSocketState.onOpen) {
+				if (typeof dynCall !== 'undefined')
+					Module.dynCall_vi(webSocketState.onOpen, instanceId);
+				else
+					{{{ makeDynCall('vi', 'webSocketState.onOpen') }}}(instanceId);
+			}
 
 		};
 
@@ -170,7 +174,10 @@ var LibraryWebSocket = {
 				HEAPU8.set(dataBuffer, buffer);
 
 				try {
-					Module.dynCall_viii(webSocketState.onMessage, instanceId, buffer, dataBuffer.length);
+					if (typeof dynCall !== 'undefined')
+						Module.dynCall_viii(webSocketState.onMessage, instanceId, buffer, dataBuffer.length);
+					else
+						{{{ makeDynCall('viii', 'webSocketState.onMessage') }}}(instanceId, buffer, dataBuffer.length);
 				} finally {
 					_free(buffer);
 				}
@@ -182,7 +189,10 @@ var LibraryWebSocket = {
 				HEAPU8.set(dataBuffer, buffer);
 
 				try {
-					Module.dynCall_viii(webSocketState.onMessage, instanceId, buffer, dataBuffer.length);
+					if (typeof dynCall !== 'undefined')
+						Module.dynCall_viii(webSocketState.onMessage, instanceId, buffer, dataBuffer.length);
+					else
+						{{{ makeDynCall('viii', 'webSocketState.onMessage') }}}(instanceId, buffer, dataBuffer.length);
 				} finally {
 					_free(buffer);
 				}
@@ -204,7 +214,10 @@ var LibraryWebSocket = {
 				stringToUTF8(msg, buffer, length);
 
 				try {
-					Module.dynCall_vii(webSocketState.onError, instanceId, buffer);
+					if (typeof dynCall !== 'undefined')
+						Module.dynCall_vii(webSocketState.onError, instanceId, buffer);
+					else
+						{{{ makeDynCall('vii', 'webSocketState.onError') }}}(instanceId, buffer);
 				} finally {
 					_free(buffer);
 				}
@@ -218,8 +231,12 @@ var LibraryWebSocket = {
 			if (webSocketState.debug)
 				console.log("[JSLIB WebSocket] Closed.");
 
-			if (webSocketState.onClose)
-				Module.dynCall_vii(webSocketState.onClose, instanceId, ev.code);
+			if (webSocketState.onClose) {
+				if (typeof dynCall !== 'undefined')
+					Module.dynCall_vii(webSocketState.onClose, instanceId, ev.code);
+				else
+					{{{ makeDynCall('vii', 'webSocketState.onClose') }}}(instanceId, ev.code);
+			}
 
 			delete instance.ws;
 


### PR DESCRIPTION
`Module.dynCall` does not work in Unity 6 with WebAssembly.Table enabled (which is forced on if targeting WebAssembly 2023), and according to [this](https://docs.unity3d.com/6000.0/Documentation/Manual/web-interacting-browser-deprecated.html), it should be replaced with an Emscripten macro `{{{ makeDynCall(...) }}}(...);`

However, since this syntax isn't supported by all older versions of Unity, to keep this backwards compatible I use a conditional `if (typeof dynCall != 'undefined')` to use the old syntax if `dynCall` is available. 